### PR TITLE
added txt2man as install requirements

### DIFF
--- a/README
+++ b/README
@@ -147,6 +147,7 @@ On Debian systems, the package names are:
     - libncurses5-dev
     - libxml2
     - libxml2-dev
+    - txt2man
     - zlib1g
     - zlib1g-dev
 


### PR DESCRIPTION
when I tried to make install on my ubuntu 13.10 system it required txt2man package.
