### PR TITLE
Port to ncursesw6

### DIFF
--- a/configure
+++ b/configure
@@ -3583,7 +3583,11 @@ fi
 
       if test "${ac_cv_lib_ncursesw_wget_wch}" == "yes"; then
         curses_found=1
-        curses_config=ncursesw5-config
+        if test -n "$(type -p ncursesw6-config)" ; then
+          curses_config=ncursesw6-config
+        else
+          curses_config=ncursesw5-config
+        fi
       fi
       ;;
   pdcurses)

--- a/configure.in
+++ b/configure.in
@@ -55,7 +55,11 @@ case ${use_curses_lib} in
       AC_CHECK_LIB(ncursesw, wget_wch)
       if test "${ac_cv_lib_ncursesw_wget_wch}" == "yes"; then
         curses_found=1
-        curses_config=ncursesw5-config
+        if test -n "$(type -p ncursesw6-config)" ; then
+          curses_config=ncursesw6-config
+        else
+          curses_config=ncursesw5-config
+        fi
       fi
       ;;
   pdcurses)

--- a/interface_gui.c
+++ b/interface_gui.c
@@ -1876,7 +1876,7 @@ int initializeScreen(void)
     assume_default_colors(-1, -1);
 
     /* we do not want any ESC delay */
-    ESCDELAY = 0;
+    set_escdelay(0);
 
     /* start color mode */
     initCDKColor();


### PR DESCRIPTION
ESCDELAY is removed in ncursesw6, but set_escdelay() is available in
ncursesw5 already, so that can be changed unconditionally, it seems to
me.