### PR TITLE
Fix build failure with GCC 10

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -33,6 +33,8 @@
 #include "listhandler.h"
 #include "memory.h"
 
+cpmconfig_t*  config;
+cpmruntime_t* runtime;
 
 /* #############################################################################
  *

--- a/configuration.h
+++ b/configuration.h
@@ -101,8 +101,8 @@ typedef struct
 /* #############################################################################
  * global variables
  */
-cpmconfig_t*            config;
-cpmruntime_t*           runtime;
+extern cpmconfig_t*     config;
+extern cpmruntime_t*    runtime;
 
 #define CRACKLIB_OFF    0
 #define CRACKLIB_ON     1


### PR DESCRIPTION
cpm fails to build from source in GCC 10 and higher due to multiple declaration errors.